### PR TITLE
replaces size() with length

### DIFF
--- a/assets/js/payform.js
+++ b/assets/js/payform.js
@@ -1,5 +1,5 @@
 jQuery(document).ready(function($){
-	if (jQuery('form#order_review').size()>0) {
+	if (jQuery('form#order_review').length>0) {
 
 		jQuery('#bambora-payform-bank-payments .bank-button').on('click',function() {
 			jQuery('#bambora-payform-bank-payments .bank-button').removeClass('selected');

--- a/bambora-payform-payment-gateway.php
+++ b/bambora-payform-payment-gateway.php
@@ -3,7 +3,7 @@
  * Plugin Name: Bambora PayForm Payment Gateway
  * Plugin URI: https://payform.bambora.com/docs
  * Description: Bambora PayForm Payment Gateway Integration for Woocommerce
- * Version: 2.1.6
+ * Version: 2.1.7
  * Author: Bambora
  * Author URI: https://www.bambora.com/fi/fi/Verkkokauppa/Payform/
  * Text Domain: bambora-payform-payment-gateway

--- a/includes/lib/Bambora/PayForm.php
+++ b/includes/lib/Bambora/PayForm.php
@@ -66,7 +66,7 @@ class PayForm
 		else
 			$payment_data['plugin_info'] .= '0';
 
-		$payment_data['plugin_info'] .= '|2.1.6';
+		$payment_data['plugin_info'] .= '|2.1.7';
 
 		return $this->makeRequest($url, $payment_data);
 	}


### PR DESCRIPTION
Wordpress uses jQuery v1.12.4 by default in addition to jQuery migrate, so in default setup this should not cause any errors. Although the function is deprecated in 1.8.0 and removed in 3.0. Lenght should be used instead. Fixes #1 